### PR TITLE
docs: [MAD-16747] document the app-sources repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+**Ticket:** <!-- Hyperlink the issue, e.g. [MAD-123](https://liquidweb.atlassian.net/browse/MAD-123) — required, or state why there isn't one -->
+
+**Target branch:** <!-- `master` (dev + QE) or `production` (customer-facing). Say which and why. -->
+
+## Why
+
+<!-- What problem does this solve, or what requirement does it fulfill? One sentence is usually
+enough if there's a ticket — it should contain the details. -->
+
+## What
+
+<!-- Bullet points: which app, which major version, which versions added or removed, and whether
+`latest-version` moved. -->
+
+### Blast radius
+
+<!-- Which fleet does this reach on merge? `production` is customer-facing; `master` is dev/QE, with
+the caveats in AGENTS.md. A `latest-version` change is the highest-impact edit: platform-driven
+installs always take it. -->
+
+## Test plan
+
+**Tarball availability:**
+- [ ] pubfiles application (Magento 2 / Shopware 6) — the tarball **and** its `.md5` are served:
+      `curl -sfI https://pubfiles.nexcess.net/<path>/<name>-<version>.tar.gz`
+      then the same URL with `.md5` appended
+- [ ] legacy application — tarball and `.md5` committed alongside the manifest, as LFS pointers
+- [ ] WordPress — the tarball column is the literal `none`
+
+**Manifest checks** (see [AGENTS.md](../AGENTS.md#checks-before-opening-a-pr)):
+- [ ] every `versions` line is `version|tarball` with both fields populated
+- [ ] `latest-version` names a version `versions` lists on this branch
+- [ ] the missing-tarball check reports only Magento 2 / Shopware 6 entries
+- [ ] the sidecar and LFS checks report only their documented pre-existing hits
+
+**Manual verification:**
+1. <!-- e.g. installed <app> <version> on a dev cloud account and confirmed the reported version -->
+
+## Deploy notes
+
+<!-- Delete this section if not needed. -->
+
+**Rollout order:** <!-- promoting to `production` after a dev/QE soak? link the master-side PR -->
+**Rollback:** <!-- revert the commit on this branch; nxcli refetches on the next install -->
+
+## Checklist
+
+- [ ] One application version bump per commit, with an `issue:` trailer
+- [ ] Branched from the branch being targeted; not a `master` → `production` merge
+- [ ] For Magento 2: the `di.xml` patch in [magento/2/README.md](../magento/2/README.md) is applied
+- [ ] Docs (`README.md`/`AGENTS.md`) updated if this changes how versions are sourced or promoted
+- [ ] No secrets, tokens, or real customer/financial data included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# app-sources
+
+Version manifests for every application the Nexcess platform installs.
+
+## Architecture in a paragraph
+
+**This repo is the only place application versioning is controlled.** Adding a line to a `versions`
+file is what makes a version installable; changing `latest-version` is what new installs get. There
+is no code, no build, no test suite, and no deploy step — merging to the branch a fleet reads *is*
+the deploy, and `nxcli` refetches these files over HTTPS at install time, so nothing here is ever
+cloned or cached. The content is three plain-text control files per application major version, laid
+out as `<app>/<major>/`. Two long-lived branches make it a two-stage promotion pipeline: `master`
+for dev and QE, `production` for the production fleet, deliberately holding different values.
+**Tarballs no longer belong here.** New applications are served from **pubfiles**
+(`pubfiles.nexcess.net`), the internal mirror hosting application tarballs ready for install;
+Magento 2 and Shopware 6 already source from it exclusively, and the committed `*.tar.gz` files are
+legacy.
+
+## File map
+
+```
+akeneo/2/                 orphaned — no application consumes this manifest
+craft/{3,4}/
+drupal/{7,8,9}/
+expressionengine/{5,6,7}/
+magento/1/
+magento/2/
+  README.md               di.xml MariaDB patch required before adding a Magento 2 tarball
+  patches/                legacy Magento patches + .md5 sidecars; no live consumer found
+shopware/6/               pubfiles-only: manifests here, tarballs on pubfiles
+sylius/1/
+wordpress/{4,5,6}/
+wordpress/4/plugins/      orphaned — nothing fetches this directory
+wordpress/5/plugins/      BigCommerce OAuth connector zips; live, see Conventions
+.gitattributes            routes *.tar.gz through git-LFS
+```
+
+## The three control files
+
+Every `<app>/<major>/` directory holds the same three files.
+
+| File | Format | Role |
+|---|---|---|
+| `versions` | one `version\|tarball` pair per line | the full set of installable versions |
+| `latest-version` | a single version string | the version installs actually get |
+| `latest-tarball` | a tarball filename, or empty | legacy; no live consumer |
+
+Format rules that matter, because nothing validates them on merge:
+
+- **Both fields on every line.** A line with no `|` maps that version to nothing and the install
+  fails later at the checksum step, with a misleading error. Use the literal `none` when there is no
+  tarball, as every WordPress line does.
+- **A trailing blank line is harmless** — the file is trimmed before parsing. `magento/2/versions`
+  has one today. An interior blank line is not harmless.
+- **Ordering is not parsed**, but keep entries ascending so a reviewer can see what was added.
+- **`latest-version` must name a version `versions` lists on the same branch.**
+- **Directory names are a contract.** `nxcli` computes the path from the application name and major
+  version, so never rename one. Creating a *new* major-version directory (`craft/5/`,
+  `wordpress/7/`) does nothing on its own — `nxcli` only reaches majors it explicitly supports, and
+  falls back to its newest supported major otherwise.
+
+## Where tarballs come from
+
+The manifests are uniform; tarball sourcing is not. Three modes coexist:
+
+| Mode | Applications | Tarball source |
+|---|---|---|
+| **pubfiles** (current) | Magento 2, Shopware 6 | `pubfiles.nexcess.net`, filename derived from the version |
+| GitHub raw (legacy) | Craft, Drupal, ExpressionEngine, Magento 1, Sylius | committed here, next to the manifest |
+| upstream | WordPress | wordpress.org, via `wp core download` |
+
+New applications use pubfiles; do not commit new tarballs. For a pubfiles application the filename
+is derived from the version rather than read from the manifest, so adding a version needs two
+independent things to be true: the line exists here, **and** pubfiles already serves the tarball.
+Fill the tarball column in truthfully regardless — it is what a reviewer scans.
+
+**Every tarball needs an adjacent `.md5`.** The installer fetches `<tarball-url>.md5` and compares
+it on every install, pubfiles included, even when the tarball is already cached on the server. A
+missing or stale sidecar fails the install. This applies to tarballs published on pubfiles too.
+
+## Checks before opening a PR
+
+There is nothing to build or test. Run these.
+
+```bash
+# Every versions line must be `version|tarball` with both fields populated.
+# Expected: one "blank line" hit for magento/2/versions — its harmless trailing newline.
+git ls-files '*/versions' | while read -r f; do
+  awk -F'|' 'NF==0 {print FILENAME": "FNR": blank line"}
+             NF!=0 && (NF!=2 || $1=="" || $2=="") {print FILENAME": "FNR": "$0}' "$f"
+done
+
+# latest-version must name a version that versions actually lists.
+git ls-files '*/latest-version' | while read -r f; do
+  d=$(dirname "$f"); v=$(tr -d '\n' < "$f")
+  cut -d'|' -f1 "$d/versions" | grep -qxF "$v" || echo "$d: latest-version '$v' absent from versions"
+done
+
+# Referenced tarballs with no committed file.
+# Expected: only Magento 2 and Shopware 6 entries, which pubfiles serves.
+git ls-files '*/versions' | while read -r f; do
+  d=$(dirname "$f")
+  cut -d'|' -f2 "$f" | grep -vx -e none -e '' | while read -r t; do
+    [ -f "$d/$t" ] || echo "$d/$t"
+  done
+done
+
+# Every committed tarball needs an .md5 beside it.
+# Expected: craft/3/craft-3.7.39.tar.gz.md5 — a pre-existing gap.
+git ls-files '*.tar.gz' | while read -r t; do
+  [ -f "$t.md5" ] || echo "missing sidecar: $t.md5"
+done
+
+# Committed tarballs stored as plain blobs instead of git-LFS pointers.
+# Expected: seven pre-existing hits under craft/, drupal/9, expressionengine/.
+git ls-files '*.tar.gz' | while read -r t; do
+  head -c 40 "$t" | grep -q 'git-lfs.github.com' || echo "not LFS: $t"
+done
+
+# What is staged on master but not yet promoted to production.
+git fetch upstream
+git diff upstream/production upstream/master -- '*/versions' '*/latest-version' '*/latest-tarball'
+```
+
+## Conventions
+
+- **`master` is not production.** Landing a version on `master` exposes it to dev and QE;
+  production reads the `production` branch, promoted by its own PR. Two paths pin `master`
+  regardless, so treat it as potentially customer-reachable rather than assumed safe: the
+  `wordpress/5/plugins/` mirror below, and the EL6-era `nxcli-legacy` build, which has no branch
+  option at all.
+- **A merge is a live change.** `nxcli` refetches on every install, so a bad `latest-version`
+  affects the next install on that branch's fleet. There is no deploy gate behind this repo.
+- **`latest-version` is what platform-driven installs get**, not merely a default. A provision from
+  the platform never names a specific version — it always takes `latest-version`. The other
+  `versions` entries are reachable only by invoking `nxcli` directly with an explicit version.
+- **Before adding any Magento 2 version, read [magento/2/README.md](magento/2/README.md)** — the
+  `app/etc/di.xml` MariaDB version pattern must be patched first.
+- **`*.tar.gz` is git-LFS tracked** (`.gitattributes`, since 2018), but seven committed tarballs are
+  plain git blobs — added by commits that bypassed the LFS filter, such as GitHub web-UI uploads. If
+  you must add a tarball, commit it from a clone with `git-lfs` installed and confirm with the LFS
+  check above. Prefer pubfiles.
+- **`wordpress/5/plugins/*.zip` is live and bypasses promotion.** A cron pulls those zips from the
+  `master` branch every 30 minutes and stages them on customer-facing servers. The `wordpress/5`
+  source path is used regardless of the WordPress major being installed, which is why
+  `wordpress/4/plugins/` is orphaned — and because it pins `master`, editing a zip reaches customers
+  without a `production` PR.
+- **One version bump per commit**, with the `issue:` trailer — see
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## See also
+
+- [README.md](README.md) — what this repo is and how to add a version
+- [magento/2/README.md](magento/2/README.md) — mandatory Magento 2 pre-upload patch
+- [CONTRIBUTING.md](CONTRIBUTING.md) — branch, commit, and PR conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Version manifests for every application the Nexcess platform installs.
+
+A change here is a live change to what customers can install. There is no CI, no validator, and no
+deploy gate — review is the only check, so make the diff easy to verify.
+
+## Development setup
+
+Nothing to install or build. See [AGENTS.md](AGENTS.md#checks-before-opening-a-pr) for the pre-merge
+checks — not repeated here.
+
+## Pick the right branch
+
+| Target | Branch |
+|---|---|
+| Expose a version to dev and QE | `master` |
+| Promote a version to customers | `production` |
+
+Branch from the branch you are targeting. Do not merge `master` into `production` — promotion has
+been done as its own commit on a branch cut from `production`, carrying only the entries being
+promoted. The two branches have diverged since `fda2418`.
+
+## Commits
+
+Conventional Commits plus an `issue:` trailer:
+
+```
+chore: set WP latest version to 6.9.5
+
+issue: MAD-XXXXX
+```
+
+One version bump per commit. A commit that bumps two applications is doing too much.
+
+## Opening a PR
+
+Use this repo's PR template. Target the `nexcess/app-sources` remote (`upstream` if you are working
+from a fork), not your own.
+
+## Before you open a PR
+
+- [ ] The `versions` line is `version|tarball` with both fields populated, in ascending order
+- [ ] `latest-version` names a version that `versions` lists on the same branch
+- [ ] The tarball and its `.md5` are reachable — on pubfiles for Magento 2 and Shopware 6, committed
+      here for the legacy applications, `none` for WordPress
+- [ ] Any tarball you committed is a git-LFS pointer, not a plain blob
+- [ ] The checks in [AGENTS.md](AGENTS.md#checks-before-opening-a-pr) report only their documented
+      pre-existing hits
+- [ ] For Magento 2: the `di.xml` patch in [magento/2/README.md](magento/2/README.md) is applied
+- [ ] Docs (`README.md`/`AGENTS.md`) updated if this changes how versions are sourced or promoted

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# app-sources
+
+Version manifests for every application the Nexcess platform installs.
+
+## Why this repo exists
+
+**Application versioning is controlled here and nowhere else.** When a customer provisions
+WordPress, Magento, Shopware, Drupal, Craft, ExpressionEngine, or Sylius, `nxcli` asks this repo
+which versions exist and which one to install. Adding a line here makes a version installable;
+changing one line changes what every new install gets.
+
+There is no code, no build, and no release artifact. Merging to the right branch is the deploy.
+
+Tarballs are a separate concern and are moving out. New applications are served from **pubfiles**
+(`pubfiles.nexcess.net`), the internal mirror that hosts application tarballs ready for use and
+installation. Magento 2 and Shopware 6 already source from it exclusively; the `*.tar.gz` files
+still committed here are legacy.
+
+## Layout
+
+One directory per application, then one per major version, each holding three plain-text files:
+
+```
+<app>/<major>/versions          every installable version, one `version|tarball` per line
+<app>/<major>/latest-version    the version installs get unless one is named explicitly
+<app>/<major>/latest-tarball    legacy; no live consumer
+```
+
+[AGENTS.md](AGENTS.md) has the annotated file map, the format rules, the tarball sourcing table, and
+the pre-merge checks.
+
+## Branches: master is not production
+
+| Branch | Read by |
+|---|---|
+| `master` | dev and QE |
+| `production` | the production fleet |
+
+The two branches deliberately hold different values — a version is exercised on `master` first, then
+promoted to `production` in its own PR. They have diverged since commit `fda2418`; promotion is a
+separate commit on a branch cut from `production`, not a merge of `master`.
+
+Two paths pin `master` regardless, so it is not provably customer-free — see
+[AGENTS.md](AGENTS.md#conventions).
+
+## Adding a version
+
+1. Branch from the branch you are targeting (`master` for dev/QE, `production` to promote).
+2. Add the version to `<app>/<major>/versions`, keeping ascending order.
+3. Make sure the tarball is reachable:
+   - **pubfiles application** (Magento 2, Shopware 6) — confirm the mirror already serves the
+     tarball and its `.md5`. The filename is derived from the version, so the manifest's tarball
+     column is not what gets fetched; fill it in truthfully anyway.
+   - **legacy application** — the tarball and its `.md5` must be committed alongside the manifest,
+     from a clone with `git-lfs` installed.
+   - **WordPress** — use the literal `none`; core comes from wordpress.org.
+4. Update `latest-version` when the new version should be what installs get. Platform-driven
+   provisions always take `latest-version`; they cannot request anything else.
+5. Run the checks in [AGENTS.md](AGENTS.md#checks-before-opening-a-pr).
+6. Open a PR against `upstream`.
+
+Magento 2 has an extra mandatory step before any tarball is added — see
+[magento/2/README.md](magento/2/README.md).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
**Ticket:** [MAD-16747](https://liquidweb.atlassian.net/browse/MAD-16747)

**Target branch:** `master` — docs only, so there is nothing to promote to `production` afterward.

## Why

This repo had no documentation at any level, so the two facts that govern every change to it were
only discoverable by reading `nxcli`: that application versioning is controlled here and nowhere
else, and that tarballs now come from **pubfiles** rather than being committed. The
`master`/`production` promotion model, the `versions` file format, and the MD5 sidecar requirement
were equally undocumented.

## What

- `AGENTS.md` — canonical, agent-facing: architecture, annotated file map, the three control files
  and their format rules, the tarball sourcing table (pubfiles / GitHub raw / upstream), runnable
  pre-merge checks, and conventions
- `CLAUDE.md` — symlink to `AGENTS.md` (mode `120000`), so the two cannot drift
- `README.md` — human-facing: why the repo exists, layout, branch model, how to add a version
- `CONTRIBUTING.md` — branch, commit, and PR conventions
- `.github/PULL_REQUEST_TEMPLATE.md` — ticket link, target branch, blast radius, test plan,
  checklist. This PR is its first use.

`magento/2/README.md` is untouched and is linked from all three root docs.

### Blast radius

Documentation only. No manifest, tarball, `latest-version`, or branch content changed — the diff is
five new files and nothing else, so no install path is affected on either branch.

## Reading guide

| File | What to look at | Why |
|---|---|---|
| `AGENTS.md` | the Conventions section | Carries the non-obvious claims: that `master` is not provably customer-free, that `latest-version` is what platform installs actually get, and that `wordpress/5/plugins/` bypasses promotion. Worth a second opinion. |
| `AGENTS.md` | "Where tarballs come from" | The pubfiles/legacy/upstream split. Confirm the per-application grouping matches your understanding. |
| `README.md` | "Adding a version" | The procedure most people will actually follow. |

## Test plan

Documentation only — **NOQA** for QE purposes. What was verified:

- Every check command in `AGENTS.md` was executed against this repo, and each "Expected:" note is
  its real output, not a guess. They surface three pre-existing conditions, all recorded in the
  ticket rather than changed here:
  - `magento/2/versions` has a harmless trailing blank line
  - `craft/3/craft-3.7.39.tar.gz` has no `.md5` sidecar, while `craft/3/versions` lists that version
  - seven committed tarballs are plain git blobs rather than git-LFS pointers
- `CLAUDE.md` resolves to identical content as `AGENTS.md` (`cmp`), and is stored as a symlink in
  git, not a copy
- All relative links and heading anchors resolve; no line-number citations; markdown tables valid
- Drafts were re-reviewed against the consumer code by a second pass, which corrected three claims
  the first draft got backwards — the WordPress plugin zips *are* consumed, `latest-tarball` has no
  live consumer, and the non-LFS tarballs are caused by commits bypassing the LFS filter rather than
  by pre-LFS history

## Checklist

- [x] One logical unit per commit, with an `issue:` trailer
- [x] Branched from the branch being targeted; not a `master` → `production` merge
- [x] For Magento 2: n/a — no Magento version or tarball added
- [x] Docs updated (this is the change)
- [x] No secrets, tokens, or real customer/financial data included

issue: MAD-16747


[MAD-16747]: https://liquidweb.atlassian.net/browse/MAD-16747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ